### PR TITLE
makefile/linux: Fix missing linker flag -ldl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifeq ($(platform), unix)
    ifneq ($(shell uname -p | grep -E '((i.|x)86|amd64)'),)
       IS_X86 = 1
    endif
-   LDFLAGS += $(PTHREAD_FLAGS)
+   LDFLAGS += $(PTHREAD_FLAGS) -ldl
    FLAGS += $(PTHREAD_FLAGS) -DHAVE_MKDIR
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib


### PR DESCRIPTION
The core uses dlopen on linux but doesn't specifiy -ldl resulting in undefined reference errors:

mednafen/snes/src/chip/supergameboy/supergameboy.o: In function `nall::library::close()':
mednafen/snes/src/lib/nall/dl.hpp:57: undefined reference to `dlclose'
mednafen/snes/src/chip/supergameboy/supergameboy.o: In function `nall::library::open(char const*)':
mednafen/snes/src/lib/nall/dl.hpp:39: undefined reference to `dlopen'
mednafen/snes/src/lib/nall/dl.hpp:52: undefined reference to `dlsym'

Env: Ubuntu Xenial, GCC 5.4

Not sure if there's a better place to put the missing flag.