### PR TITLE
Remove unused value

### DIFF
--- a/mednafen/snes/src/lib/nall/string/match.hpp
+++ b/mednafen/snes/src/lib/nall/string/match.hpp
@@ -54,7 +54,7 @@ bool match(const char *p, const char *s) {
 
     //literal match
     if(*p == *s) {
-      p++, *s++;
+      p++;
       continue;
     }
 


### PR DESCRIPTION
Removes an unused value silencing the following warnings.
```
In file included from ./mednafen/snes/src/lib/nall/string.hpp:10:0,
                 from mednafen/snes/src/cartridge/../base.hpp:32,
                 from mednafen/snes/src/cartridge/cartridge.cpp:1:
./mednafen/snes/src/lib/nall/string/match.hpp: In function ‘bool match(const char*, const char*)’:
./mednafen/snes/src/lib/nall/string/match.hpp:57:16: warning: value computed is not used [-Wunused-value]
       p++, *s++;
                ^
In file included from ./mednafen/snes/src/lib/nall/string.hpp:10:0,
                 from ./mednafen/snes/src/lib/../base.hpp:32,
                 from mednafen/snes/src/chip/srtc/srtc.cpp:1:
./mednafen/snes/src/lib/nall/string/match.hpp: In function ‘bool match(const char*, const char*)’:
./mednafen/snes/src/lib/nall/string/match.hpp:57:16: warning: value computed is not used [-Wunused-value]
       p++, *s++;
                ^
In file included from ./mednafen/snes/src/lib/nall/string.hpp:10:0,
                 from ./mednafen/snes/src/lib/../base.hpp:32,
                 from mednafen/snes/src/cheat/cheat.cpp:1:
./mednafen/snes/src/lib/nall/string/match.hpp: In function ‘bool match(const char*, const char*)’:
./mednafen/snes/src/lib/nall/string/match.hpp:57:16: warning: value computed is not used [-Wunused-value]
       p++, *s++;
                ^
In file included from ./mednafen/snes/src/lib/nall/string.hpp:10:0,
                 from ./mednafen/snes/src/lib/../base.hpp:32,
                 from mednafen/snes/src/chip/21fx/21fx.cpp:1:
./mednafen/snes/src/lib/nall/string/match.hpp: In function ‘bool match(const char*, const char*)’:
./mednafen/snes/src/lib/nall/string/match.hpp:57:16: warning: value computed is not used [-Wunused-value]
       p++, *s++;
                ^
In file included from ./mednafen/snes/src/lib/nall/string.hpp:10:0,
                 from ./mednafen/snes/src/lib/../base.hpp:32,
                 from mednafen/snes/src/chip/bsx/bsx.cpp:1:
./mednafen/snes/src/lib/nall/string/match.hpp: In function ‘bool match(const char*, const char*)’:
./mednafen/snes/src/lib/nall/string/match.hpp:57:16: warning: value computed is not used [-Wunused-value]
       p++, *s++;
                ^
In file included from ./mednafen/snes/src/lib/nall/string.hpp:10:0,
                 from mednafen/snes/src/base.hpp:32,
                 from mednafen/snes/interface.cpp:20:
./mednafen/snes/src/lib/nall/string/match.hpp: In function ‘bool match(const char*, const char*)’:
./mednafen/snes/src/lib/nall/string/match.hpp:57:16: warning: value computed is not used [-Wunused-value]
       p++, *s++;
                ^
```