### PR TITLE
Silence a -Wswitch-bool warning

### DIFF
--- a/mednafen/snes/src/chip/sa1/dma/dma.cpp
+++ b/mednafen/snes/src/chip/sa1/dma/dma.cpp
@@ -32,16 +32,13 @@ void SA1::dma_normal() {
       } break;
     }
 
-    switch(mmio.dd) {
-      case DMA::DestBWRAM: {
-        if((dda & 0x40e000) == 0x006000 || (dda & 0xf00000) == 0x400000) {
-          sa1bus.write(dda, data);
-        }
-      } break;
-
-      case DMA::DestIRAM: {
-        memory::iram.write(dda & 0x07ff, data);
-      } break;
+    if((mmio.dd) == DMA::DestBWRAM) {
+      if((dda & 0x40e000) == 0x006000 || (dda & 0xf00000) == 0x400000) {
+        sa1bus.write(dda, data);
+      }
+    }
+    else if((mmio.dd) == DMA::DestIRAM) {
+      memory::iram.write(dda & 0x07ff, data);
     }
   }
 


### PR DESCRIPTION
Silences the following warning.
```
In file included from mednafen/snes/src/chip/sa1/sa1.cpp:10:0:
mednafen/snes/src/chip/sa1/dma/dma.cpp: In member function ‘void SNES::SA1::dma_normal()’:
mednafen/snes/src/chip/sa1/dma/dma.cpp:35:19: warning: switch condition has type bool [-Wswitch-bool]
     switch(mmio.dd) {
                   ^
```
According to the following links using a switch statement with boolean value may not the best idea and an if-else statement would be preferable.

https://stackoverflow.com/questions/26411482/switch-condition-has-boolean-value
https://stackoverflow.com/questions/25075017/warning-switch-condition-has-boolean-value