### PR TITLE
Revert "Better error handling"

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -187,7 +187,7 @@ static void hookup_ports(bool force)
 
 bool retro_load_game(const struct retro_game_info *info)
 {
-   if (!info || failed_init)
+   if (failed_init)
       return false;
 
 #ifdef WANT_32BPP


### PR DESCRIPTION
This reverts commit 74d78da09738546d38ef5e239fb5115802329a39.

This is not needed to prevent a segfault so might as well be removed. See libretro/RetroArch#4493