### PR TITLE
Silence three -Wparentheses warnings

### DIFF
--- a/mednafen/snes/src/chip/cx4/cx4.cpp
+++ b/mednafen/snes/src/chip/cx4/cx4.cpp
@@ -195,7 +195,7 @@ uint16 Cx4::readw(uint16 addr) {
 }
 
 uint32 Cx4::readl(uint16 addr) {
-  return read(addr) | (read(addr + 1) << 8) + (read(addr + 2) << 16);
+  return read(addr) | ((read(addr + 1) << 8) + (read(addr + 2) << 16));
 }
 
 void Cx4::power() {

--- a/mednafen/snes/src/chip/sdd1/sdd1emu.cpp
+++ b/mednafen/snes/src/chip/sdd1/sdd1emu.cpp
@@ -258,13 +258,15 @@ uint8 SDD1_PEM::getBit(uint8 context) {
 
   bit=(BG[pState->code_num])->getBit(&endOfRun);
 
-  if (endOfRun)
+  if (endOfRun) {
     if (bit) {
       if (!(currStatus & 0xfe)) (pContInfo->MPS)^=0x01;
       (pContInfo->status)=pState->nextIfLPS;
     }
-    else
+    else {
       (pContInfo->status)=pState->nextIfMPS;
+    }
+  }
 
   return bit^currentMPS;
 

--- a/mednafen/snes/src/cpu/core/opcode_misc.cpp
+++ b/mednafen/snes/src/cpu/core/opcode_misc.cpp
@@ -72,7 +72,7 @@ L rd.h = op_readlong(vectorN + 1);
 }
 
 void CPUcore::op_stp() {
-  while(regs.wai = true) {
+  while((regs.wai = true)) {
 L   op_io();
   }
 }


### PR DESCRIPTION
Silences the following threes -Wparentheses warnings.
```
mednafen/snes/src/chip/cx4/cx4.cpp: In member function ‘uint32 SNES::Cx4::readl(uint16)’:
mednafen/snes/src/chip/cx4/cx4.cpp:198:45: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
   return read(addr) | (read(addr + 1) << 8) + (read(addr + 2) << 16);
                                             ^
In file included from mednafen/snes/src/chip/sdd1/sdd1.cpp:9:0:
mednafen/snes/src/chip/sdd1/sdd1emu.cpp: In member function ‘uint8 SNES::SDD1_PEM::getBit(uint8)’:
mednafen/snes/src/chip/sdd1/sdd1emu.cpp:261:6: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wparentheses]
   if (endOfRun)
      ^
In file included from mednafen/snes/src/cpu/core/core.cpp:23:0:
mednafen/snes/src/cpu/core/opcode_misc.cpp: In member function ‘void SNES::CPUcore::op_stp()’:
mednafen/snes/src/cpu/core/opcode_misc.cpp:75:20: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
   while(regs.wai = true) {
                    ^
```