### PR TITLE
Silence two -Wswitch warning

### DIFF
--- a/mednafen/snes/src/chip/dsp1/dsp1.cpp
+++ b/mednafen/snes/src/chip/dsp1/dsp1.cpp
@@ -27,6 +27,11 @@ void DSP1::enable() {
       bus.map(Bus::MapDirect, 0x00, 0x1f, 0x6000, 0x7fff, *this);
       bus.map(Bus::MapDirect, 0x80, 0x9f, 0x6000, 0x7fff, *this);
     } break;
+
+    case Cartridge::DSP1Unmapped: {
+      default:
+        break;
+    }
   }
 }
 
@@ -64,6 +69,11 @@ bool DSP1::addr_decode(uint16 addr) {
     case Cartridge::DSP1HiROM: {
     //$[00-1f]:[6000-6fff] = DR, $[00-1f]:[7000-7fff] = SR
       return (addr >= 0x7000);
+    }
+
+    case Cartridge::DSP1Unmapped: {
+      default:
+        break;
     }
   }
 


### PR DESCRIPTION
Silences the following two `-Wswitch` warnings.
```
mednafen/snes/src/chip/dsp1/dsp1.cpp: In member function ‘void SNES::DSP1::enable()’:
mednafen/snes/src/chip/dsp1/dsp1.cpp:15:9: warning: enumeration value ‘DSP1Unmapped’ not handled in switch [-Wswitch]
   switch(cartridge.dsp1_mapper()) {
         ^
mednafen/snes/src/chip/dsp1/dsp1.cpp: In member function ‘bool SNES::DSP1::addr_decode(uint16)’:
mednafen/snes/src/chip/dsp1/dsp1.cpp:53:9: warning: enumeration value ‘DSP1Unmapped’ not handled in switch [-Wswitch]
   switch(cartridge.dsp1_mapper()) {
         ^
```