### PR TITLE
Silence a -Wbool-compare warning

### DIFF
--- a/mednafen/snes/interface.cpp
+++ b/mednafen/snes/interface.cpp
@@ -273,7 +273,8 @@ int16_t MeowFace::input_poll(bool port, unsigned device, unsigned index, unsigne
 
 	case SNES::Input::DeviceMouse:
 	{
-	 assert(port < 2);
+	 int port_type = port;
+	 assert(port_type < 2);
 	 switch(id)
 	 {
 	  case SNES::Input::MouseX:


### PR DESCRIPTION
Silences a `-Wbool-compare` warning.
```
In file included from ./mednafen/include/blargg_common.h:9:0,
                 from ./mednafen/include/Fir_Resampler.h:7,
                 from mednafen/snes/interface.cpp:22:
mednafen/snes/interface.cpp: In member function ‘virtual int16_t MeowFace::input_poll(bool, unsigned int, unsigned int, unsigned int)’:
mednafen/snes/interface.cpp:276:15: warning: comparison of constant ‘2’ with boolean expression is always true [-Wbool-compare]
   assert(port < 2);
               ^
```