### PR TITLE
Silence a -Waggressive-loop-optimizations warning

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -168,7 +168,7 @@ static void check_variables(void)
 }
 
 #define MAX_PLAYERS 5
-#define MAX_BUTTONS 14
+#define MAX_BUTTONS 12 
 static uint8_t input_buf[MAX_PLAYERS][2];
 
 


### PR DESCRIPTION
Silences a `-Waggressive-loop-optimizations` warning.
```
libretro.cpp: In function ‘void update_input()’:
libretro.cpp:264:39: warning: iteration 12u invokes undefined behavior [-Waggressive-loop-optimizations]
          input_state |= input_state_cb(j, RETRO_DEVICE_JOYPAD, 0, map[i]) ? (1 << i) : 0;
                                       ^
libretro.cpp:263:21: note: containing loop
       for (i = 0; i < MAX_BUTTONS; i++)
                     ^
```
As I understand, beetle-bsnes-libretro should have 12 `MAX_BUTTONS`, not 14.
```
   static unsigned map[] = {
      RETRO_DEVICE_ID_JOYPAD_B,
      RETRO_DEVICE_ID_JOYPAD_Y,
      RETRO_DEVICE_ID_JOYPAD_SELECT,                                          
      RETRO_DEVICE_ID_JOYPAD_START,
      RETRO_DEVICE_ID_JOYPAD_UP,   
      RETRO_DEVICE_ID_JOYPAD_DOWN,
      RETRO_DEVICE_ID_JOYPAD_LEFT,
      RETRO_DEVICE_ID_JOYPAD_RIGHT,
      RETRO_DEVICE_ID_JOYPAD_A,
      RETRO_DEVICE_ID_JOYPAD_X,
      RETRO_DEVICE_ID_JOYPAD_L,
      RETRO_DEVICE_ID_JOYPAD_R,
   };
```