### PR TITLE
Makefile cleanup, make DEBUG more like other cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,13 +205,8 @@ WARNINGS := -Wall \
 	$(NEW_GCC_WARNING_FLAGS) \
 	-Wno-strict-aliasing
 
-EXTRA_GCC_FLAGS := -funroll-loops
-
 ifeq ($(NO_GCC),1)
-	EXTRA_GCC_FLAGS :=
-	WARNINGS :=
-else
-	EXTRA_GCC_FLAGS := -g
+   WARNINGS :=
 endif
 
 OBJECTS := $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o)
@@ -219,9 +214,9 @@ OBJECTS := $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o)
 all: $(TARGET)
 
 ifeq ($(DEBUG),0)
-   FLAGS += -O2 $(EXTRA_GCC_FLAGS)
+   FLAGS += -O2 -DNDEBUG
 else
-   FLAGS += -O0
+   FLAGS += -O0 -g -DDEBUG
 endif
 
 LDFLAGS += $(fpic) $(SHARED)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -42,10 +42,9 @@ include ../Makefile.common
 LDFLAGS += -ldl
 
 LOCAL_SRC_FILES += $(SOURCES_CXX) $(SOURCES_C)
-EXTRA_GCC_FLAGS := -funroll-loops
 
 ifeq ($(DEBUG),0)
-   FLAGS += -O3 $(EXTRA_GCC_FLAGS)
+   FLAGS += -O3
 else
    FLAGS += -O0 -g
 endif


### PR DESCRIPTION
This will do the following.
1. Removes `EXTRA_GCC_FLAGS`, `-funroll-loops` is probably not advisable to use.
2. Uses `-g` with `DEBUG=1`.