### PR TITLE
Remove uneeded -Wno-warning flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,9 +201,7 @@ WARNINGS := -Wall \
 	-Wno-sign-compare \
 	-Wno-unused-variable \
 	-Wno-unused-function \
-	-Wno-uninitialized \
-	$(NEW_GCC_WARNING_FLAGS) \
-	-Wno-strict-aliasing
+	-Wno-uninitialized
 
 ifeq ($(NO_GCC),1)
    WARNINGS :=


### PR DESCRIPTION
Minor makefile cleanup.
1. Remove `Wno-strict-aliasing`, I was not able to reproduce any new warnings without this.
2. Remove `$(NEW_GCC_WARNING_FLAGS)` as it doesn't seem to do anything...