### PR TITLE
Silence -Wdelete-non-virtual-dtor warnings (Please review)

### DIFF
--- a/mednafen/snes/src/lib/nall/any.hpp
+++ b/mednafen/snes/src/lib/nall/any.hpp
@@ -21,7 +21,10 @@ namespace nall {
       if(type() == typeid(auto_t)) {
         static_cast<holder<auto_t>*>(container)->value = (auto_t)value_;
       } else {
-        if(container) delete container;
+        if(container) {
+          any *container = new any();
+          delete container;
+        }
         container = new holder<auto_t>((auto_t)value_);
       }
 


### PR DESCRIPTION
NOTE: I am not sure I have this right, are there better ways of doing this?

Silences the following spammed `-Wdelete-non-virtual-dtor` warnings if compiled with clang.
```
In file included from mednafen/snes/src/cartridge/cartridge.cpp:1:
In file included from mednafen/snes/src/cartridge/../base.hpp:18:
./mednafen/snes/src/lib/nall/any.hpp:24:23: warning: delete called on 'nall::any::placeholder' that
      is abstract but has non-virtual destructor [-Wdelete-non-virtual-dtor]
        if(container) delete container;
                      ^
``` 

Some references.
https://stackoverflow.com/questions/270917/why-should-i-declare-a-virtual-destructor-for-an-abstract-class-in-c
https://stackoverflow.com/questions/8764353/what-does-has-virtual-method-but-non-virtual-destructor-warning-mean-durin