### PR TITLE
Silence -Wtautological-compare warnings

### DIFF
--- a/mednafen/snes/src/lib/nall/file.hpp
+++ b/mednafen/snes/src/lib/nall/file.hpp
@@ -97,7 +97,7 @@ namespace nall {
       if(!fp) return;  //file not open
       buffer_flush();
 
-      uintmax_t req_offset = file_offset;
+      intmax_t req_offset = file_offset;
       switch(mode) {
         case seek_absolute: req_offset  = offset; break;
         case seek_relative: req_offset += offset; break;


### PR DESCRIPTION
Silences spammed `-Wtautological-compare` warnings with clang, based on what I have read `req_offset` should be signed.
```
In file included from mednafen/snes/src/cartridge/../base.hpp:24:
./mednafen/snes/src/lib/nall/file.hpp:106:21: warning: comparison of unsigned expression < 0 is
      always false [-Wtautological-compare]
      if(req_offset < 0) req_offset = 0;  //cannot seek before start of file
         ~~~~~~~~~~ ^ ~
```