### PR TITLE
Silence a -Wself-assign-field warning

### DIFF
--- a/mednafen/snes/src/chip/cx4/opcodes.cpp
+++ b/mednafen/snes/src/chip/cx4/opcodes.cpp
@@ -107,7 +107,6 @@ void Cx4::op1f() {
   } else {
     double tanval = ((double)C41FYVal) / ((double)C41FXVal);
     C41FAngleRes = (short)(atan(tanval) / (PI * 2) * 512);
-    C41FAngleRes = C41FAngleRes;
     if(C41FXVal < 0) {
       C41FAngleRes += 0x100;
     }


### PR DESCRIPTION
Silences a `-Wself-assign-field` warning with clang.
```
In file included from mednafen/snes/src/chip/cx4/cx4.cpp:18:
mednafen/snes/src/chip/cx4/opcodes.cpp:110:18: warning: assigning field to itself
      [-Wself-assign-field]
    C41FAngleRes = C41FAngleRes;
                 ^
```
See https://github.com/libretro/bsnes-mercury/blob/master/sfc/chip/cx4/opcodes.cpp#L100.