### PR TITLE
Silence -Wmaybe-unitialized warnings (Please review)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,8 +200,7 @@ include Makefile.common
 WARNINGS := -Wall \
 	-Wno-sign-compare \
 	-Wno-unused-variable \
-	-Wno-unused-function \
-	-Wno-uninitialized
+	-Wno-unused-function
 
 ifeq ($(NO_GCC),1)
    WARNINGS :=

--- a/mednafen/snes/src/chip/superfx/core/core.cpp
+++ b/mednafen/snes/src/chip/superfx/core/core.cpp
@@ -51,7 +51,7 @@ uint8 SuperFX::rpix(uint8 x, uint8 y) {
   pixelcache_flush(pixelcache[1]);
   pixelcache_flush(pixelcache[0]);
 
-  unsigned cn;  //character number
+  unsigned cn = 0;  //character number
   switch(regs.por.obj ? 3 : regs.scmr.ht) {
     case 0: cn = ((x & 0xf8) << 1) + ((y & 0xf8) >> 3); break;
     case 1: cn = ((x & 0xf8) << 1) + ((x & 0xf8) >> 1) + ((y & 0xf8) >> 3); break;
@@ -78,7 +78,7 @@ void SuperFX::pixelcache_flush(pixelcache_t &cache) {
   uint8 x = cache.offset << 3;
   uint8 y = cache.offset >> 5;
 
-  unsigned cn;  //character number
+  unsigned cn = 0;  //character number
   switch(regs.por.obj ? 3 : regs.scmr.ht) {
     case 0: cn = ((x & 0xf8) << 1) + ((y & 0xf8) >> 3); break;
     case 1: cn = ((x & 0xf8) << 1) + ((x & 0xf8) >> 1) + ((y & 0xf8) >> 3); break;

--- a/mednafen/snes/src/ppu/bppu/render/bg.cpp
+++ b/mednafen/snes/src/ppu/bppu/render/bg.cpp
@@ -87,13 +87,13 @@ void bPPU::render_line_bg(uint8 pri0_pos, uint8 pri1_pos) {
     if(regs.interlace) y = (y << 1) + field();
   }
 
-  uint16 hval, vval;
-  uint16 tile_pri, tile_num;
-  uint8  pal_index, pal_num;
+  uint16 hval = 0, vval = 0;
+  uint16 tile_pri = 0, tile_num;
+  uint8  pal_index = 0, pal_num = 0;
   uint16 hoffset, voffset, opt_x, col;
-  bool   mirror_x, mirror_y;
+  bool   mirror_x = 0, mirror_y;
 
-  const uint8  *tile_ptr;
+  const uint8  *tile_ptr = 0;
   const uint16 *mtable = mosaic_table[regs.mosaic_enabled[bg] ? regs.mosaic_size : 0];
   const bool   is_opt_mode = (mode == 2 || mode == 4 || mode == 6);
   const bool   is_direct_color_mode = (regs.direct_color == true && bg == BG1 && (mode == 3 || mode == 4));

--- a/mednafen/snes/src/ppu/bppu/render/mode7.cpp
+++ b/mednafen/snes/src/ppu/bppu/render/mode7.cpp
@@ -17,7 +17,7 @@ void bPPU::render_line_mode7(uint8 pri0_pos, uint8 pri1_pos) {
   if(regs.bg_enabled[bg] == false && regs.bgsub_enabled[bg] == false) return;
 
   int32 px, py;
-  int32 tx, ty, tile, palette;
+  int32 tx, ty, tile, palette = 0;
 
   int32 a = sclip<16>(cache.m7a);
   int32 b = sclip<16>(cache.m7b);

--- a/mednafen/snes/src/system/serialization.cpp
+++ b/mednafen/snes/src/system/serialization.cpp
@@ -18,7 +18,7 @@ serializer System::serialize() {
 }
 
 bool System::unserialize(serializer &s) {
-  unsigned signature, version, crc32;
+  unsigned signature = 0, version = 0, crc32 = 0;
   char description[512];
 
   s.integer(signature);


### PR DESCRIPTION
Here are some commits to try to correctly silence the various `-Wmaybe-unitialized` warnings with gcc.
http://pastebin.com/xaZKik8u
```
In file included from mednafen/snes/src/chip/superfx/superfx.cpp:8:0:
mednafen/snes/src/chip/superfx/core/core.cpp: In member function ‘void SNES::SuperFX::pixelcache_flush(SNES::SuperFX::pixelcache_t&)’:
mednafen/snes/src/chip/superfx/core/core.cpp:89:34: warning: ‘cn’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   unsigned addr = 0x700000 + (cn * (bpp << 3)) + (regs.scbr << 10) + ((y & 0x07) * 2);
                                  ^
mednafen/snes/src/chip/superfx/core/core.cpp: In member function ‘uint8 SNES::SuperFX::rpix(uint8, uint8)’:
mednafen/snes/src/chip/superfx/core/core.cpp:62:34: warning: ‘cn’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```
```
In file included from mednafen/snes/src/ppu/bppu/render/render.cpp:9:0,
                 from mednafen/snes/src/ppu/bppu/bppu.cpp:15:
mednafen/snes/src/ppu/bppu/render/line.cpp: In member function ‘void SNES::bPPU::render_line_mode7(uint8, uint8) [with unsigned int bg = 0u; uint8 = unsigned char]’:
mednafen/snes/src/ppu/bppu/render/line.cpp:4:31: warning: ‘palette’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   const unsigned addr = index << 1;
                               ^
In file included from mednafen/snes/src/ppu/bppu/render/render.cpp:7:0,
                 from mednafen/snes/src/ppu/bppu/bppu.cpp:15:
mednafen/snes/src/ppu/bppu/render/mode7.cpp:20:23: note: ‘palette’ was declared here
   int32 tx, ty, tile, palette;
                       ^
mednafen/snes/src/ppu/bppu/render/mode7.cpp: In member function ‘void SNES::bPPU::render_line_mode7(uint8, uint8) [with unsigned int bg = 1u; uint8 = unsigned char ’:
mednafen/snes/src/ppu/bppu/render/mode7.cpp:20:23: warning: ‘palette’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```
```
In file included from mednafen/snes/src/system/system.cpp:10:0:
mednafen/snes/src/system/serialization.cpp: In member function ‘bool SNES::System::unserialize(nall::serializer&)’:
mednafen/snes/src/system/serialization.cpp:21:12: warning: ‘signature’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   unsigned signature, version, crc32;
            ^
mednafen/snes/src/system/serialization.cpp:21:23: warning: ‘version’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   unsigned signature, version, crc32;
                       ^
In file included from ./mednafen/snes/src/lib/nall/moduloarray.hpp:4:0,
                 from ./mednafen/snes/src/lib/../base.hpp:26,
                 from mednafen/snes/src/system/system.cpp:1:
./mednafen/snes/src/lib/nall/serializer.hpp:58:44: warning: ‘crc32’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         for(unsigned n = 0; n < size; n++) idata[isize++] = (uint64_t)value >> (n << 3);
                                            ^
In file included from mednafen/snes/src/system/system.cpp:10:0:
mednafen/snes/src/system/serialization.cpp:21:32: note: ‘crc32’ was declared here
   unsigned signature, version, crc32;
                                ^
```