### PR TITLE
Silence another -Wself-assign warning

### DIFF
--- a/mednafen/snes/src/chip/dsp3/dsp3emu.c
+++ b/mednafen/snes/src/chip/dsp3/dsp3emu.c
@@ -997,7 +997,7 @@ void DSP3_OP10()
 		DSP3_Reset();
 	} else {
 		// absorb 2 bytes
-		DSP3_DR = DSP3_DR;
+		(void) DSP3_DR;
 	}
 }
 


### PR DESCRIPTION
Silences a `-Wself-assign` warning with clang.
```
In file included from mednafen/snes/src/chip/dsp3/dsp3.cpp:10:
mednafen/snes/src/chip/dsp3/dsp3emu.c:1000:11: warning: explicitly assigning value
      of variable of type 'uint16' (aka 'unsigned short') to itself
      [-Wself-assign]
                DSP3_DR = DSP3_DR;
                ~~~~~~~ ^ ~~~~~~~
```
Reference: https://forums.pragprog.com/forums/123/topics/11156