### PR TITLE
[android] switch to c++_static APP_STL

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_STL := gnustl_static 
+APP_STL := c++_static
 APP_ABI := all


### PR DESCRIPTION
gnustl_static stl isn't available in NDK 18 and higher.
This PR fixes the following build error.

[...]/android-ndk-r18/build/core/add-application.mk:178: *** Android NDK: APP_STL gnustl_static is no longer supported. Please switch to either c++_static or c++_shared. See https://developer.android.com/ndk/guides/cpp-support.html for more information.    .  Stop.
