### PR TITLE
mednafen: use std::vector and std::array instead of manual memory allocations

### DIFF
--- a/mednafen/mednafen.cpp
+++ b/mednafen/mednafen.cpp
@@ -220,7 +220,7 @@ void MDFN_printf(const char *format, ...)
       lastchar = format[x];
    }
 
-   format_temp = (char *)malloc(newlen + 1); // Length + NULL character, duh
+   format_temp = new char[newlen + 1]; // Length + NULL character, duh
 
    // Now, construct our format_temp string
    lastchar = lastchar_backup; // Restore lastchar
@@ -240,10 +240,10 @@ void MDFN_printf(const char *format, ...)
 
    temp = new char[4096];
    vsnprintf(temp, 4096, format_temp, ap);
-   free(format_temp);
+   delete[] format_temp;
 
    MDFND_Message(temp);
-   free(temp);
+   delete[] temp;
 
    va_end(ap);
 }
@@ -259,7 +259,7 @@ void MDFN_PrintError(const char *format, ...)
  temp = new char[4096];
  vsnprintf(temp, 4096, format, ap);
  MDFND_PrintError(temp);
- free(temp);
+ delete[] temp;
 
  va_end(ap);
 }
@@ -275,7 +275,7 @@ void MDFN_DebugPrintReal(const char *file, const int line, const char *format, .
  temp = new char[4096];
  vsnprintf(temp, 4096, format, ap);
  fprintf(stderr, "%s:%d  %s\n", file, line, temp);
- free(temp);
+ delete[] temp;
 
  va_end(ap);
 }

--- a/mednafen/mednafen.cpp
+++ b/mednafen/mednafen.cpp
@@ -22,8 +22,6 @@
 #include	<errno.h>
 #include	<list>
 #include	<algorithm>
-#include <array>
-#include <vector>
 
 #include	"general.h"
 
@@ -200,6 +198,8 @@ static uint8 lastchar = 0;
 
 void MDFN_printf(const char *format, ...)
 {
+   char *format_temp;
+   char *temp;
    unsigned int x, newlen;
 
    va_list ap;
@@ -220,7 +220,7 @@ void MDFN_printf(const char *format, ...)
       lastchar = format[x];
    }
 
-   std::vector<char> format_temp(newlen + 1); // Length + NULL character, duh
+   format_temp = (char *)malloc(newlen + 1); // Length + NULL character, duh
 
    // Now, construct our format_temp string
    lastchar = lastchar_backup; // Restore lastchar
@@ -238,36 +238,44 @@ void MDFN_printf(const char *format, ...)
 
    format_temp[newlen] = 0;
 
-   std::array<char, 4096> temp;
-   vsnprintf(temp.data(), temp.size(), format_temp.data(), ap);
+   temp = new char[4096];
+   vsnprintf(temp, 4096, format_temp, ap);
+   free(format_temp);
 
-   MDFND_Message(temp.data());
+   MDFND_Message(temp);
+   free(temp);
 
    va_end(ap);
 }
 
 void MDFN_PrintError(const char *format, ...)
 {
+ char *temp;
+
  va_list ap;
 
  va_start(ap, format);
 
- std::array<char, 4096> temp;
- vsnprintf(temp.data(), temp.size(), format, ap);
- MDFND_PrintError(temp.data());
+ temp = new char[4096];
+ vsnprintf(temp, 4096, format, ap);
+ MDFND_PrintError(temp);
+ free(temp);
 
  va_end(ap);
 }
 
 void MDFN_DebugPrintReal(const char *file, const int line, const char *format, ...)
 {
+ char *temp;
+
  va_list ap;
 
  va_start(ap, format);
 
- std::array<char, 4096> temp;
- vsnprintf(temp.data(), temp.size(), format, ap);
- fprintf(stderr, "%s:%d  %s\n", file, line, temp.data());
+ temp = new char[4096];
+ vsnprintf(temp, 4096, format, ap);
+ fprintf(stderr, "%s:%d  %s\n", file, line, temp);
+ free(temp);
 
  va_end(ap);
 }

--- a/mednafen/mednafen.cpp
+++ b/mednafen/mednafen.cpp
@@ -199,7 +199,6 @@ static uint8 lastchar = 0;
 void MDFN_printf(const char *format, ...)
 {
    char *format_temp;
-   char *temp;
    unsigned int x, newlen;
 
    va_list ap;
@@ -238,44 +237,37 @@ void MDFN_printf(const char *format, ...)
 
    format_temp[newlen] = 0;
 
-   temp = new char[4096];
+   char temp[4096];
    vsnprintf(temp, 4096, format_temp, ap);
    delete[] format_temp;
 
    MDFND_Message(temp);
-   delete[] temp;
 
    va_end(ap);
 }
 
 void MDFN_PrintError(const char *format, ...)
 {
- char *temp;
-
  va_list ap;
 
  va_start(ap, format);
 
- temp = new char[4096];
+ char temp[4096];
  vsnprintf(temp, 4096, format, ap);
  MDFND_PrintError(temp);
- delete[] temp;
 
  va_end(ap);
 }
 
 void MDFN_DebugPrintReal(const char *file, const int line, const char *format, ...)
 {
- char *temp;
-
  va_list ap;
 
  va_start(ap, format);
 
- temp = new char[4096];
+ char temp[4096];
  vsnprintf(temp, 4096, format, ap);
  fprintf(stderr, "%s:%d  %s\n", file, line, temp);
- delete[] temp;
 
  va_end(ap);
 }

--- a/mednafen/mednafen.cpp
+++ b/mednafen/mednafen.cpp
@@ -22,6 +22,8 @@
 #include	<errno.h>
 #include	<list>
 #include	<algorithm>
+#include <array>
+#include <vector>
 
 #include	"general.h"
 
@@ -198,8 +200,6 @@ static uint8 lastchar = 0;
 
 void MDFN_printf(const char *format, ...)
 {
-   char *format_temp;
-   char *temp;
    unsigned int x, newlen;
 
    va_list ap;
@@ -220,7 +220,7 @@ void MDFN_printf(const char *format, ...)
       lastchar = format[x];
    }
 
-   format_temp = (char *)malloc(newlen + 1); // Length + NULL character, duh
+   std::vector<char> format_temp(newlen + 1); // Length + NULL character, duh
 
    // Now, construct our format_temp string
    lastchar = lastchar_backup; // Restore lastchar
@@ -238,44 +238,36 @@ void MDFN_printf(const char *format, ...)
 
    format_temp[newlen] = 0;
 
-   temp = new char[4096];
-   vsnprintf(temp, 4096, format_temp, ap);
-   free(format_temp);
+   std::array<char, 4096> temp;
+   vsnprintf(temp.data(), temp.size(), format_temp.data(), ap);
 
-   MDFND_Message(temp);
-   free(temp);
+   MDFND_Message(temp.data());
 
    va_end(ap);
 }
 
 void MDFN_PrintError(const char *format, ...)
 {
- char *temp;
-
  va_list ap;
 
  va_start(ap, format);
 
- temp = new char[4096];
- vsnprintf(temp, 4096, format, ap);
- MDFND_PrintError(temp);
- free(temp);
+ std::array<char, 4096> temp;
+ vsnprintf(temp.data(), temp.size(), format, ap);
+ MDFND_PrintError(temp.data());
 
  va_end(ap);
 }
 
 void MDFN_DebugPrintReal(const char *file, const int line, const char *format, ...)
 {
- char *temp;
-
  va_list ap;
 
  va_start(ap, format);
 
- temp = new char[4096];
- vsnprintf(temp, 4096, format, ap);
- fprintf(stderr, "%s:%d  %s\n", file, line, temp);
- free(temp);
+ std::array<char, 4096> temp;
+ vsnprintf(temp.data(), temp.size(), format, ap);
+ fprintf(stderr, "%s:%d  %s\n", file, line, temp.data());
 
  va_end(ap);
 }


### PR DESCRIPTION
This also fixes the following problems (#42) : 

```
mednafen/mednafen.cpp: In function ‘void MDFN_printf(const char*, ...)’: mednafen/mednafen.cpp:246:8: warning: ‘void free(void*)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  246 |    free(temp);
      |    ~~~~^~~~~~
mednafen/mednafen.cpp:241:24: note: returned from ‘void* operator new [](std::size_t)’
  241 |    temp = new char[4096];
      |                        ^
mednafen/mednafen.cpp: In function ‘void MDFN_PrintError(const char*, ...)’:
mednafen/mednafen.cpp:262:6: warning: ‘void free(void*)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  262 |  free(temp);
      |  ~~~~^~~~~~
mednafen/mednafen.cpp:259:22: note: returned from ‘void* operator new [](std::size_t)’
  259 |  temp = new char[4096];
      |                      ^
mednafen/mednafen.cpp: In function ‘void MDFN_DebugPrintReal(const char*, int, const char*, ...)’:
mednafen/mednafen.cpp:278:6: warning: ‘void free(void*)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  278 |  free(temp);
      |  ~~~~^~~~~~
mednafen/mednafen.cpp:275:22: note: returned from ‘void* operator new [](std::size_t)’
  275 |  temp = new char[4096];
      |                      ^
```