### PR TITLE
Build fix for unix-armv7-hardfloat-neon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,8 +242,9 @@ else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
-   CC = gcc
+   CC ?= gcc
    IS_X86 = 0
+   LDFLAGS += -ldl
 ifneq (,$(findstring cortexa8,$(platform)))
    FLAGS += -marm -mcpu=cortex-a8
    ASFLAGS += -mcpu=cortex-a8


### PR DESCRIPTION
Build was not successful for unix-armv7-hardfloat-neon, -ldl was missing.