### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -88,6 +92,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of Beetle bSNES, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: the `unix` branch of the Makefile is arch-neutral, there is no x86 assembly or SSE in the build, and `android-arm64-v8a`, `osx-arm64`, `ios-arm64` and `tvos-arm64` already build these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include. (The file uses CRLF line endings; the patch keeps them.)

Verified natively on aarch64 (postmarketOS, glibc, GCC 15): `make platform=unix` builds clean with no source changes, producing `mednafen_snes_libretro.so` (ELF 64-bit ARM aarch64), and the core loads and initialises in a libretro host. This is a build/load verification - I have no SNES ROM here to run through it.
